### PR TITLE
Support tinc routing

### DIFF
--- a/service/etcd2/etcd2.go
+++ b/service/etcd2/etcd2.go
@@ -124,7 +124,10 @@ func createEtcdConfig(deps service.ServiceDependencies, flags *service.ServiceFl
 	memberIndex := 0
 	for index, cm := range members {
 		if !cm.EtcdProxy {
-			initialCluster = append(initialCluster, fmt.Sprintf("%s=http://%s:2380", cm.MachineID, cm.ClusterIP))
+			initialCluster = append(initialCluster,
+				fmt.Sprintf("%s=http://%s:2380", cm.MachineID, cm.ClusterIP),
+				fmt.Sprintf("%s=https://%s:2381", cm.MachineID, cm.PrivateHostIP),
+			)
 			endpoints = append(endpoints, fmt.Sprintf("http://%s:%d", cm.ClusterIP, clientPort))
 			hosts = append(hosts, cm.ClusterIP)
 		}

--- a/service/iptables/iptables.go
+++ b/service/iptables/iptables.go
@@ -158,9 +158,11 @@ func createV4Rules(deps service.ServiceDependencies, flags *service.ServiceFlags
 	opts := struct {
 		DockerSubnet         string
 		PrivateClusterDevice string
+		ClusterSubnet        string
 	}{
 		DockerSubnet:         flags.Docker.DockerSubnet,
 		PrivateClusterDevice: flags.Network.PrivateClusterDevice,
+		ClusterSubnet:        flags.Network.ClusterSubnet,
 	}
 	changed, err := templates.Render(v4rulesTemplate, v4rulesPath, opts, rulesFileMode)
 	return changed, maskAny(err)

--- a/service/service.go
+++ b/service/service.go
@@ -16,6 +16,7 @@ package service
 
 import (
 	"io/ioutil"
+	"net"
 	"os"
 	"path/filepath"
 	"strings"
@@ -64,6 +65,7 @@ type ServiceFlags struct {
 	// Network
 	Network struct {
 		PrivateClusterDevice string
+		ClusterSubnet        string // 'a.b.c.d/x'
 		ClusterIP            string // IP address of member used for internal cluster traffic (e.g. etcd)
 	}
 
@@ -140,6 +142,12 @@ func (flags *ServiceFlags) SetupDefaults(log *logging.Logger) error {
 	}
 	if flags.Network.PrivateClusterDevice == "" {
 		flags.Network.PrivateClusterDevice = "eth1"
+	}
+	if flags.Network.ClusterSubnet == "" {
+		ip := net.ParseIP(flags.Network.ClusterIP)
+		mask := ip.DefaultMask()
+		network := net.IPNet{IP: ip, Mask: mask}
+		flags.Network.ClusterSubnet = network.String()
 	}
 	if flags.GluonImage == "" {
 		content, err := ioutil.ReadFile(gluonImagePath)

--- a/setup.go
+++ b/setup.go
@@ -28,7 +28,6 @@ import (
 	"github.com/pulcy/gluon/service/iptables"
 	"github.com/pulcy/gluon/service/journal"
 	"github.com/pulcy/gluon/service/nomad"
-	"github.com/pulcy/gluon/service/proxy"
 	"github.com/pulcy/gluon/service/rkt"
 	"github.com/pulcy/gluon/service/sshd"
 	"github.com/pulcy/gluon/service/weave"
@@ -105,7 +104,7 @@ func runSetup(cmd *cobra.Command, args []string) {
 	services := []service.Service{
 		binaries.NewService(),
 		env.NewService(),
-		proxy.NewService(),
+		//proxy.NewService(),
 		iptables.NewService(),
 		journal.NewService(),
 		docker.NewService(),

--- a/templates/ip4tables.rules.tmpl
+++ b/templates/ip4tables.rules.tmpl
@@ -4,6 +4,7 @@
 :OUTPUT ACCEPT [0:0]
 :POSTROUTING ACCEPT [0:0]
 -A POSTROUTING -s {{.DockerSubnet}} ! -d {{.DockerSubnet}} -j MASQUERADE
+-A POSTROUTING -s {{.ClusterSubnet}} -o eth0 -j MASQUERADE
 COMMIT
 
 *filter
@@ -33,6 +34,8 @@ COMMIT
 
 -A INPUT -m conntrack --ctstate RELATED,ESTABLISHED -j ACCEPT
 -A INPUT -i {{.PrivateClusterDevice}} -j PRIVATECLUSTER
+-A FORWARD -i {{.PrivateClusterDevice}} -o eth0 -s {{.ClusterSubnet}} -j ACCEPT
+-A FORWARD -o {{.PrivateClusterDevice}} -i eth0 -d {{.ClusterSubnet}} -j ACCEPT
 
 -A FORWARD -i {{.PrivateClusterDevice}} -o docker0 -j PRIVATECLUSTER
 -A FORWARD -o docker0 -m conntrack --ctstate RELATED,ESTABLISHED -j ACCEPT


### PR DESCRIPTION
This PR updates IP tables rules to support routing from hosts without a public IPv4 internet connection over TINC through hosts that do have a public IPv4 internet connection.